### PR TITLE
Specify Google Maps API version in script tag

### DIFF
--- a/Source/Support/SubPanel/Map/AeroQuad.cfg
+++ b/Source/Support/SubPanel/Map/AeroQuad.cfg
@@ -10,7 +10,7 @@
 </style> 
 
 <script type="text/javascript"    
-	src="http://maps.googleapis.com/maps/api/js?v=3.18&sensor=false"> 
+  src="http://maps.googleapis.com/maps/api/js?v=3.18&sensor=false"> 
 </script> 
 
 <script type="text/javascript">

--- a/Source/Support/SubPanel/Map/AeroQuad.cfg
+++ b/Source/Support/SubPanel/Map/AeroQuad.cfg
@@ -9,8 +9,8 @@
   #map_canvas { height: 100% } 
 </style> 
 
-<script type="text/javascript" 
-    src="http://maps.googleapis.com/maps/api/js?sensor=false"> 
+<script type="text/javascript"    
+	src="http://maps.googleapis.com/maps/api/js?v=3.18&sensor=false"> 
 </script> 
 
 <script type="text/javascript">

--- a/Source/Support/SubPanel/Map/AeroQuad.cfg
+++ b/Source/Support/SubPanel/Map/AeroQuad.cfg
@@ -9,8 +9,8 @@
   #map_canvas { height: 100% } 
 </style> 
 
-<script type="text/javascript"    
-  src="http://maps.googleapis.com/maps/api/js?v=3.18&sensor=false"> 
+<script type="text/javascript"
+  src="http://maps.googleapis.com/maps/api/js?v=3.18&sensor=false">
 </script> 
 
 <script type="text/javascript">


### PR DESCRIPTION
Seems to be necessary since the 2015/02/17 API update to 3.20
